### PR TITLE
Setup GoReleaser 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+---
 name: goreleaser
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: goreleaser
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ">=1.19.2"
+          cache: true
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Release directory
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,8 @@
 # Documentation: https://goreleaser.com
 project_name: license
+archives:
+  - format: binary
+    name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
 builds:
   - main: .
     env:
@@ -13,10 +16,12 @@ builds:
       - darwin
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
+    mod_timestamp: "{{ .CommitTimestamp }}"
 checksum:
   name_template: "SHA256SUMS.txt"
   algorithm: sha256
 changelog:
+  use: github
   sort: asc
   filters:
     exclude:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,9 @@
+---
 # Documentation: https://goreleaser.com
 project_name: license
 archives:
   - format: binary
-    name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    name_template: '{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}' # yamllint disable-line
 builds:
   - main: .
     env:
@@ -15,7 +16,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser # yamllint disable-line
     mod_timestamp: "{{ .CommitTimestamp }}"
 checksum:
   name_template: "SHA256SUMS.txt"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,30 @@
+# Documentation: https://goreleaser.com
+project_name: license
+builds:
+  - main: .
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm64
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser
+checksum:
+  name_template: "SHA256SUMS.txt"
+  algorithm: sha256
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+release:
+  github:
+    owner: nishanths
+    name: license
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -14,10 +15,15 @@ import (
 	"github.com/tcnksm/go-gitconfig"
 )
 
-const (
-	nameEnv       = "LICENSE_FULL_NAME"
-	versionString = "v5"
+var (
+	version = "dev"
+	commit  = ""
+	date    = ""
+	builtBy = ""
+)
 
+const (
+	nameEnv     = "LICENSE_FULL_NAME"
 	usageString = `Usage: license [flags] [license-type]
 
 Flags:
@@ -98,7 +104,18 @@ func run() {
 }
 
 func printVersion() {
-	stdout.Printf("%s", versionString)
+	stdout.Printf("license version %s", version)
+	if commit != "" {
+		stdout.Printf("commit: %s", commit)
+	}
+	if date != "" {
+		stdout.Printf("built at: %s", date)
+	}
+	if builtBy != "" {
+		stdout.Printf("built by: %s", builtBy)
+	}
+	stdout.Printf("goos: %s", runtime.GOOS)
+	stdout.Printf("goarch: %s", runtime.GOARCH)
 }
 
 func printUsage() {


### PR DESCRIPTION
Closes #41.

This PR adds a basic [GoReleaser](https://goreleaser.com) config that builds and releases the following binaries:

- license-v0.0.0-darwin-amd64
- license-v0.0.0-darwin-arm64
- license-v0.0.0-linux-amd64
- license-v0.0.0-linux-arm64
- license-v0.0.0-windows-amd64.exe
- license-v0.0.0-windows-arm64.exe

To test locally, check out this branch and (ensuring there are no uncommitted changes), run `goreleaser release --snapshot --rm-dist`. This creates a local-only "snapshot" release (sort of a dry-run). You should see something like so:

```
[sbaney@Skips-MacBook-Air:~/src/license] $ goreleaser release --snapshot --rm-dist
  • starting release...
  • loading config file                              file=.goreleaser.yaml
  • loading environment variables
  • getting and validating git state
    • ignoring errors because this is a snapshot     error=git doesn't contain any tags. Either add a tag or use --snapshot
    • building...                                    commit=525e90896488dc45d368de1643d047ab11769f6b latest tag=v0.0.0
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=0.0.1-next
  • checking distribution directory
    • --rm-dist is set, cleaning it up
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/license_darwin_arm64/license
    • building                                       binary=dist/license_windows_amd64_v1/license.exe
    • building                                       binary=dist/license_darwin_amd64_v1/license
    • building                                       binary=dist/license_windows_arm64/license.exe
    • building                                       binary=dist/license_linux_arm64/license
    • building                                       binary=dist/license_linux_amd64_v1/license
  • archives
    • skip archiving                                 binary=license name=license-v0.0.0-darwin-arm64
    • skip archiving                                 binary=license name=license-v0.0.0-linux-amd64
    • skip archiving                                 binary=license name=license-v0.0.0-darwin-amd64
    • skip archiving                                 binary=license.exe name=license-v0.0.0-windows-arm64.exe
    • skip archiving                                 binary=license name=license-v0.0.0-linux-arm64
    • skip archiving                                 binary=license.exe name=license-v0.0.0-windows-amd64.exe
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 0s
```

and the `./dist` directory will include a bunch of build artifacts that under a normal release would have been uploaded to a new GitHub release.

```shell
$ cat ./dist/SHA256SUMS.txt

00ceec02b570c90a9dd92e9b1346c39332f3b8b6a374aefc3b5e34fbdce3de98  license-v0.0.0-windows-arm64.exe
7c8db8b426210d734e016095f9638a341b19034438b7d00aa581b5c3cdc64c3d  license-v0.0.0-darwin-amd64
90798811add04f39f8f00515a499b080dbdfff4756e8dcae986aa9afc97ba55b  license-v0.0.0-windows-amd64.exe
c60d668f351be79e303538d7949deaaa48d28b007c94c726b3cfb6b47d10bd2b  license-v0.0.0-linux-arm64
f931bfe0b2de28b3a4bf5db2d2ecad91de9aa28835a4b0bfa10a51b9be35ac3a  license-v0.0.0-darwin-arm64
f98a96be90b820ed2dbdc61ce28b16b381c9ac85bf67d6082c596b7463444355  license-v0.0.0-linux-amd64
```

Also modified the version string to include the build info (since GoReleaser makes it easy to do so):

```shell
$ ./dist/license_darwin_arm64/license -v
license version 0.0.1-next
commit: 525e90896488dc45d368de1643d047ab11769f6b
built at: 2022-10-11T20:05:38Z
built by: goreleaser
goos: darwin
goarch: arm64
```

Also added a GH actions workflow that should automate the process of publishing new releases whenever a new tag is created. All you should need to do is follow [the instructions here](https://goreleaser.com/ci/actions/) regarding adding a GITHUB_TOKEN with the appropriate permissions.
